### PR TITLE
Remove zero-width space unicode characters

### DIFF
--- a/src/main/java/org/kantega/notsoserial/NotSoSerialClassFileTransformer.java
+++ b/src/main/java/org/kantega/notsoserial/NotSoSerialClassFileTransformer.java
@@ -33,7 +33,7 @@ public class NotSoSerialClassFileTransformer implements ClassFileTransformer {
         blacklist.add(internalName("org.apache.commons.collections4.functors.InvokerTransformer"));
         blacklist.add(internalName("org.apache.commons.collections.functors.InstantiateTransformer"));
         blacklist.add(internalName("org.apache.commons.collections4.functors.InstantiateTransformer"));
-        blacklist.add(internalName("org.codehaus.groovy.​runtime.​ConvertedClosure"));
+        blacklist.add(internalName("org.codehaus.groovy.runtime.ConvertedClosure"));
         blacklist.add(internalName("com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl"));
 
         String classes = System.getProperty("notsoserial.custom.classes");


### PR DESCRIPTION
The "org.codehaus.groovy.runtime.ConvertedClosure" blacklist
string in `NotSoSerialClassFileTransformer` contains two <U+200B>
characters (zero width space - http://www.fileformat.info/info/unicode/char/200B/index.htm).
So the code, as is, will not blacklist the `ConvertedClosure` class.
