### PR TITLE
CustomNotSoSerialIT failing on Windows

### DIFF
--- a/src/test/java/org/kantega/notsoserial/CustomNotSoSerialIT.java
+++ b/src/test/java/org/kantega/notsoserial/CustomNotSoSerialIT.java
@@ -47,7 +47,7 @@ public class CustomNotSoSerialIT {
     @Before
     public void before() throws IOException, URISyntaxException {
         URL resource = getClass().getResource("/META-INF/services/org.kantega.notsoserial.NotSoSerial");
-        servicesPath = Paths.get(resource.toURI().getPath());
+        servicesPath = Paths.get(resource.toURI());
         Files.write(servicesPath, (getClass().getPackage().getName() +".CustomNotSoSerial").getBytes());
     }
 


### PR DESCRIPTION
Fixes #17.

Translating URI to String and then to Path caused trouble on Windows. Paths takes an URI, so that was not needed anyway.
