### PR TITLE
Added support for jboss marshalling (version 1.2 upwards)

### DIFF
--- a/src/main/java/org/kantega/notsoserial/AbstractClassResolverClassVisitor.java
+++ b/src/main/java/org/kantega/notsoserial/AbstractClassResolverClassVisitor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Kantega AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kantega.notsoserial;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+/**
+ * Add the check for white/black listed classes to JBoss Marshalling (http://jbossmarshalling.jboss.org/). 
+ * 
+ * This class supports version 1.2 up to 1.4.10 of Jboss Marshalling and can be used for both Jboss AS and Wildfly.
+ */
+public class AbstractClassResolverClassVisitor extends ClassVisitor {
+
+    private final String loadClassDesc = "(Ljava/lang/String;)Ljava/lang/Class;";
+
+    private final String callBackDescriptor = "(Ljava/lang/String;)V";
+
+    public AbstractClassResolverClassVisitor(ClassVisitor cv) {
+        super(Opcodes.ASM5, cv);
+    }
+
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+		return new LoadClassCallSiteVisitor(mv);
+    }
+
+    public static void onBeforeLoadClass(String className) {
+    	Options.getInstance().getNotSoSerial().onBeforeResolveClass(className);
+    }
+
+    private class LoadClassCallSiteVisitor extends MethodVisitor {
+        public LoadClassCallSiteVisitor(MethodVisitor mv) {
+            super(Opcodes.ASM5, mv);
+        }
+        
+        public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            if (name.equals("loadClass") && loadClassDesc.equals(desc)) {
+                mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getType(AbstractClassResolverClassVisitor.class).getInternalName(), "onBeforeLoadClass", callBackDescriptor, false);
+            }
+            super.visitMethodInsn(opcode, owner, name, desc, itf);
+        }
+    }
+}

--- a/src/main/java/org/kantega/notsoserial/JbossAbstractClassResolverClassVisitor.java
+++ b/src/main/java/org/kantega/notsoserial/JbossAbstractClassResolverClassVisitor.java
@@ -26,13 +26,13 @@ import org.objectweb.asm.Type;
  * 
  * This class supports version 1.2 up to 1.4.10 of Jboss Marshalling and can be used for both Jboss AS and Wildfly.
  */
-public class AbstractClassResolverClassVisitor extends ClassVisitor {
+public class JbossAbstractClassResolverClassVisitor extends ClassVisitor {
 
     private final String loadClassDesc = "(Ljava/lang/String;)Ljava/lang/Class;";
 
     private final String callBackDescriptor = "(Ljava/lang/String;)V";
 
-    public AbstractClassResolverClassVisitor(ClassVisitor cv) {
+    public JbossAbstractClassResolverClassVisitor(ClassVisitor cv) {
         super(Opcodes.ASM5, cv);
     }
 
@@ -54,7 +54,7 @@ public class AbstractClassResolverClassVisitor extends ClassVisitor {
         
         public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
             if (name.equals("loadClass") && loadClassDesc.equals(desc)) {
-                mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getType(AbstractClassResolverClassVisitor.class).getInternalName(), "onBeforeLoadClass", callBackDescriptor, false);
+                mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getType(JbossAbstractClassResolverClassVisitor.class).getInternalName(), "onBeforeLoadClass", callBackDescriptor, false);
             }
             super.visitMethodInsn(opcode, owner, name, desc, itf);
         }

--- a/src/main/java/org/kantega/notsoserial/NotSoSerialAgent.java
+++ b/src/main/java/org/kantega/notsoserial/NotSoSerialAgent.java
@@ -56,6 +56,13 @@ public class NotSoSerialAgent {
                     throw new RuntimeException("Could not retransform class " + clazz.getName(), e);
                 }
             }
+            if("org.jboss.marshalling.AbstractClassResolver".equals(clazz.getName())) {
+                try {
+                    instrumentation.retransformClasses(clazz);
+                } catch (UnmodifiableClassException e) {
+                    throw new RuntimeException("Could not retransform class " + clazz.getName(), e);
+                }
+            }
         }
     }
 

--- a/src/main/java/org/kantega/notsoserial/NotSoSerialClassFileTransformer.java
+++ b/src/main/java/org/kantega/notsoserial/NotSoSerialClassFileTransformer.java
@@ -36,10 +36,10 @@ public class NotSoSerialClassFileTransformer implements ClassFileTransformer {
             reader.accept(classVisitor, 0);
             return writer.toByteArray();
         }
-        if (isAbstractClassResolver(className)) {
+        if (isJBossAbstractClassResolver(className)) {
             ClassReader reader = new ClassReader(classfileBuffer);
             ClassWriter writer = new ClassWriter(0);
-            AbstractClassResolverClassVisitor classVisitor = new AbstractClassResolverClassVisitor(writer);
+            JbossAbstractClassResolverClassVisitor classVisitor = new JbossAbstractClassResolverClassVisitor(writer);
             reader.accept(classVisitor, 0);
             return writer.toByteArray();
         }
@@ -50,7 +50,7 @@ public class NotSoSerialClassFileTransformer implements ClassFileTransformer {
         return "java/io/ObjectInputStream".equals(className);
     }
 
-    private boolean isAbstractClassResolver(String className) {
+    private boolean isJBossAbstractClassResolver(String className) {
         return "org/jboss/marshalling/AbstractClassResolver".equals(className);
     }
 

--- a/src/main/java/org/kantega/notsoserial/NotSoSerialClassFileTransformer.java
+++ b/src/main/java/org/kantega/notsoserial/NotSoSerialClassFileTransformer.java
@@ -36,11 +36,22 @@ public class NotSoSerialClassFileTransformer implements ClassFileTransformer {
             reader.accept(classVisitor, 0);
             return writer.toByteArray();
         }
+        if (isAbstractClassResolver(className)) {
+            ClassReader reader = new ClassReader(classfileBuffer);
+            ClassWriter writer = new ClassWriter(0);
+            AbstractClassResolverClassVisitor classVisitor = new AbstractClassResolverClassVisitor(writer);
+            reader.accept(classVisitor, 0);
+            return writer.toByteArray();
+        }
         return null;
     }
 
     private boolean isObjectInputStream(String className) {
         return "java/io/ObjectInputStream".equals(className);
+    }
+
+    private boolean isAbstractClassResolver(String className) {
+        return "org/jboss/marshalling/AbstractClassResolver".equals(className);
     }
 
 }


### PR DESCRIPTION
I've modified the implementation to support the jboss marshalling which performs it's own serialization/deserialization with the same blacklist/whitelist support that notsoserial already offers. 

This implementation supports Jboss Marshalling versions 1.2 up to 1.4.10 (the latest version)
