### PR TITLE
Property 'notsoserial.useDefaultBlacklist' for disabling default blacklist

### DIFF
--- a/src/main/java/org/kantega/notsoserial/DefaultNotSoSerial.java
+++ b/src/main/java/org/kantega/notsoserial/DefaultNotSoSerial.java
@@ -38,14 +38,16 @@ public class DefaultNotSoSerial implements NotSoSerial {
     private Set<String> deserializingClasses = new ConcurrentSkipListSet<String>();
 
     public DefaultNotSoSerial() {
-        blacklist.add(internalName("org.apache.commons.collections.functors.InvokerTransformer"));
-        blacklist.add(internalName("org.apache.commons.collections4.functors.InvokerTransformer"));
-        blacklist.add(internalName("org.apache.commons.collections.functors.InstantiateTransformer"));
-        blacklist.add(internalName("org.apache.commons.collections4.functors.InstantiateTransformer"));
-        blacklist.add(internalName("org.codehaus.groovy.runtime.ConvertedClosure"));
-        blacklist.add(internalName("org.codehaus.groovy.runtime.MethodClosure"));
-        blacklist.add(internalName("org.springframework.beans.factory.ObjectFactory"));
-        blacklist.add(internalName("com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl"));
+        if (System.getProperty("notsoserial.useDefaultBlacklist", "true").equals("true")) {
+            blacklist.add(internalName("org.apache.commons.collections.functors.InvokerTransformer"));
+            blacklist.add(internalName("org.apache.commons.collections4.functors.InvokerTransformer"));
+            blacklist.add(internalName("org.apache.commons.collections.functors.InstantiateTransformer"));
+            blacklist.add(internalName("org.apache.commons.collections4.functors.InstantiateTransformer"));
+            blacklist.add(internalName("org.codehaus.groovy.runtime.ConvertedClosure"));
+            blacklist.add(internalName("org.codehaus.groovy.runtime.MethodClosure"));
+            blacklist.add(internalName("org.springframework.beans.factory.ObjectFactory"));
+            blacklist.add(internalName("com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl"));
+        }
 
         String blacklistProperty = System.getProperty("notsoserial.blacklist");
         if(blacklistProperty != null) {


### PR DESCRIPTION
When running with a whitelist a blacklist only adds unnecessary overhead, so this way you can disable the default black list.

This property is 'true' by default so it will not impact the default behavior.
